### PR TITLE
use File::Slurper instead of File::Slurp

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,7 +4,7 @@ requires 'Throwable';
 requires 'aliased';
 requires 'Try::Tiny';
 requires 'File::Find';
-requires 'File::Slurp';
+requires 'File::Slurper';
 requires 'YAML::XS';
 requires 'Log::Log4perl';
 requires 'File::Spec';

--- a/lib/MooseX/DIC/Configuration/Scanner/FileConfig.pm
+++ b/lib/MooseX/DIC/Configuration/Scanner/FileConfig.pm
@@ -1,7 +1,6 @@
 package MooseX::DIC::Configuration::Scanner::FileConfig;
 
 use File::Find;
-use File::Slurp;
 
 require Exporter;
 @ISA       = qw/Exporter/;

--- a/lib/MooseX/DIC/Configuration/Scanner/Injectable.pm
+++ b/lib/MooseX/DIC/Configuration/Scanner/Injectable.pm
@@ -1,7 +1,8 @@
 package MooseX::DIC::Configuration::Scanner::Injectable;
 
 use File::Find;
-use File::Slurp;
+use File::Slurper 'read_text';
+use Try::Tiny;
 
 require Exporter;
 @ISA       = qw/Exporter/;
@@ -34,7 +35,7 @@ sub is_injectable {
     return 0 if index( $file_name, '.pm' ) == -1;
 
     # Must have the injectable role applied
-    my $file_content = read_file( $file_name, err_mode => 'quiet' );
+    my $file_content = try { read_text( $file_name ) };
     return 0
         unless ( $file_content
         and ( index( $file_content, 'MooseX::DIC::Injectable' ) != -1 ) );
@@ -47,7 +48,7 @@ sub extract_package_name_from_filename {
     my $file_name = shift;
 
     my $package_name;
-    my $file_content = read_file( $file_name, err_mode => 'quiet' );
+    my $file_content = try { read_text( $file_name ) };
     if ($file_content) {
         $file_content =~ /package\ +([a-zA-Z0-9]+)/;
         $package_name = $1;

--- a/lib/MooseX/DIC/Configuration/YAML.pm
+++ b/lib/MooseX/DIC/Configuration/YAML.pm
@@ -5,7 +5,7 @@ with 'MooseX::DIC::Configuration';
 
 use YAML::XS;
 use File::Spec::Functions qw/splitpath rel2abs/;
-use File::Slurp;
+use File::Slurper 'read_binary';
 use Try::Tiny;
 use MooseX::DIC::Configuration::Scanner::FileConfig 'fetch_config_files_from_path';
 use aliased 'MooseX::DIC::ContainerConfigurationException';
@@ -30,7 +30,7 @@ sub build_services_metadata_from_config_file {
   # Parse YAML config file
   my $raw_config;
   try {
-    my $config_content = read_file($config_file);
+    my $config_content = read_binary($config_file);
     $raw_config = Load $config_content;
   } catch {
     ContainerConfigurationException->throw(message=>"Error while loading config file $config_file: $_");


### PR DESCRIPTION
File::Slurp should be avoided, see: http://blogs.perl.org/users/leon_timmermans/2015/08/fileslurp-is-broken-and-wrong.html

File::Slurper is the recommended substitute, and has a very simple API for differentiating between reading files in binary and text mode, as for example here, where YAML::XS expects UTF-8 encoded binary data, but the other usage runs a regex on decoded text. I used Try::Tiny to emulate File::Slurp's "quiet" error mode, as it's used elsewhere in this distribution.