### PR TITLE
use [VersionFromMainModule]

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -19,7 +19,7 @@ on 'test' => sub {
 on 'develop' => sub {
     requires 'Dist::Zilla';
     requires 'Dist::Zilla::Plugin::Prereqs::FromCPANfile';
-    requires 'Dist::Zilla::Plugin::VersionFromModule';
+    requires 'Dist::Zilla::Plugin::VersionFromMainModule';
     requires 'Dist::Zilla::PluginBundle::Git';
     requires 'Pod::Markdown';
 };

--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ copyright_year = 2017
 license = Apache_2_0
 main_module = lib/MooseX/DIC.pm
 
-[VersionFromModule]
+[VersionFromMainModule]
 
 [Git::GatherDir]
 exclude_match=Makefile


### PR DESCRIPTION
[VersionFromModule] is in a distribution which has been failing tests for a while, it has been forked to [VersionFromMainModule].